### PR TITLE
Fix CI triggers Paths (YAML and Classic) Tips to include/exclude 

### DIFF
--- a/docs/pipelines/repos/includes/ci-triggers1.md
+++ b/docs/pipelines/repos/includes/ci-triggers1.md
@@ -111,7 +111,7 @@ When you specify paths, you must explicitly specify branches to trigger on. You 
 >  * Wild cards are not supported with path filters.
 >  * Paths are always specified relative to the root of the repository.
 >  * If you don't set path filters, then the root folder of the repo is implicitly included by default.
->  * If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude _/tools_ then you could include _/tools/trigger-runs-on-these_
+>  * If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude _tools_ then you could include _tools/trigger-runs-on-these_
 >  * The order of path filters doesn't matter.
 >  * Paths in Git *are case-sensitive*. Be sure to use the same case as the real folders.
 >  * You cannot use [variables](../../process/variables.md) in paths, as variables are evaluated at runtime (after the trigger has fired).

--- a/docs/pipelines/repos/includes/ci-triggers4.md
+++ b/docs/pipelines/repos/includes/ci-triggers4.md
@@ -30,7 +30,7 @@ You can specify the branches where you want to trigger builds. If you want to us
 If your Git repo is in Azure Repos or TFS, you can also specify path filters to reduce the set of files that you want to trigger a build.
 
 > **Tips:**
->  * Paths are always specified relative to the root of the repository.
+>  * Paths are always specified as absolute to the root of the repository.
 >  * If you don't set path filters, then the root folder of the repo is implicitly included by default.
 >  * If you exclude a path, you cannot also include it unless you qualify it to a deeper folder. For example if you exclude _/tools_ then you could include _/tools/trigger-runs-on-these_
 >  * The order of path filters doesn't matter.


### PR DESCRIPTION
A tip for include/exclude suggests using paths relative to the root of the repo. 
But the tip about using nested include on an already excluded path uses an absolute path.